### PR TITLE
chore: CI強化（lint + typecheck + test）+ CIログフック

### DIFF
--- a/.claude/hooks/ci-log.sh
+++ b/.claude/hooks/ci-log.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# PostToolUse: lint/typecheck/test コマンド実行後にログを記録するフック
+
+cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_result.exitCode // empty' 2>/dev/null)
+
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+# lint/typecheck/test コマンドのみログ対象
+if echo "$CMD" | grep -qE "npm run (lint|typecheck|test)|npm test|vitest|tsc|eslint"; then
+  LOG_DIR="$CLAUDE_PROJECT_DIR/.claude/logs"
+  mkdir -p "$LOG_DIR"
+
+  LOG_FILE="$LOG_DIR/ci-$(date +%Y-%m-%d).log"
+  TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+  if [ "$EXIT_CODE" = "0" ] || [ -z "$EXIT_CODE" ]; then
+    STATUS="PASS"
+  else
+    STATUS="FAIL (exit: $EXIT_CODE)"
+  fi
+
+  echo "[$TIMESTAMP] $STATUS | $CMD" >> "$LOG_FILE"
+fi
+
+exit 0

--- a/.claude/hooks/save-session-log.js
+++ b/.claude/hooks/save-session-log.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// セッション終了時に会話ログを自動保存するフック
+// ユーザーが送ったプロンプト一覧 + 原本JSONLを .claude/logs/ に保存する
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+let stdinData = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  stdinData += chunk;
+});
+process.stdin.on("end", () => {
+  try {
+    main(stdinData);
+  } catch (e) {
+    // フックのエラーでClaude Codeを止めない
+    process.exit(0);
+  }
+});
+// stdinが来ない場合のタイムアウト
+setTimeout(() => {
+  try {
+    main(stdinData);
+  } catch (e) {
+    process.exit(0);
+  }
+}, 5000);
+
+function main(stdin) {
+  const projectDir = process.env.CLAUDE_PROJECT_DIR;
+  if (!projectDir) return;
+
+  const logDir = path.join(projectDir, ".claude", "logs");
+  fs.mkdirSync(logDir, { recursive: true });
+
+  // セッションIDを取得（stdin or 環境変数）
+  let sessionId;
+  try {
+    const hookData = JSON.parse(stdin);
+    sessionId = hookData.session_id;
+  } catch {}
+  sessionId = sessionId || process.env.CLAUDE_SESSION_ID;
+  if (!sessionId) return;
+
+  // Claude Codeの内部データからJSONLファイルを探す
+  const homeDir = process.env.USERPROFILE || process.env.HOME;
+  const claudeProjectsDir = path.join(homeDir, ".claude", "projects");
+
+  // プロジェクトパスをClaude内部形式に変換
+  // C:\Users\OWNER\Desktop\... → C--Users-OWNER-Desktop-...
+  const internalName = projectDir.replace(/:/g, "-").replace(/[\\/]/g, "-");
+  const jsonlPath = path.join(
+    claudeProjectsDir,
+    internalName,
+    `${sessionId}.jsonl`
+  );
+
+  if (!fs.existsSync(jsonlPath)) return;
+
+  // メタデータ取得
+  let branch = "unknown";
+  try {
+    branch = execSync("git branch --show-current", {
+      cwd: projectDir,
+      encoding: "utf8",
+      timeout: 5000,
+    }).trim();
+  } catch {}
+
+  let gitUser = "unknown";
+  try {
+    gitUser = execSync("git config user.name", {
+      cwd: projectDir,
+      encoding: "utf8",
+      timeout: 5000,
+    }).trim();
+  } catch {}
+
+  // JONLを解析してユーザーメッセージを抽出
+  const lines = fs.readFileSync(jsonlPath, "utf8").split("\n").filter(Boolean);
+  const userMessages = [];
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === "user" && entry.message) {
+        const content = entry.message.content;
+        let text = "";
+        if (typeof content === "string") {
+          text = content;
+        } else if (Array.isArray(content)) {
+          // マルチモーダル（画像+テキスト等）の場合、テキスト部分だけ抽出
+          text = content
+            .filter((block) => block.type === "text")
+            .map((block) => block.text)
+            .join("\n");
+          // 画像がある場合は注記
+          const imageCount = content.filter(
+            (block) => block.type === "image"
+          ).length;
+          if (imageCount > 0) {
+            text += `\n[画像 ${imageCount}枚添付]`;
+          }
+        }
+
+        if (text.trim()) {
+          userMessages.push({
+            timestamp: entry.timestamp || "",
+            content: text.trim(),
+          });
+        }
+      }
+    } catch {}
+  }
+
+  // タイムスタンプ
+  const now = new Date();
+  const ts = now.toISOString().slice(0, 19).replace(/[T:]/g, "-");
+
+  // Markdownログを生成
+  const projectName = path.basename(projectDir);
+  let md = `# Claude Code セッションログ\n\n`;
+  md += `| 項目 | 値 |\n`;
+  md += `|------|----|\n`;
+  md += `| **プロジェクト** | ${projectName} |\n`;
+  md += `| **日時** | ${now.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })} |\n`;
+  md += `| **ユーザー** | ${gitUser} |\n`;
+  md += `| **ブランチ** | ${branch} |\n`;
+  md += `| **セッションID** | \`${sessionId}\` |\n`;
+  md += `| **プロンプト数** | ${userMessages.length} |\n\n`;
+  md += `---\n\n`;
+  md += `## プロンプト一覧\n\n`;
+
+  for (let i = 0; i < userMessages.length; i++) {
+    const msg = userMessages[i];
+    const time = msg.timestamp
+      ? new Date(msg.timestamp).toLocaleString("ja-JP", {
+          timeZone: "Asia/Tokyo",
+        })
+      : "";
+    md += `### ${i + 1}. [${time}]\n\n`;
+    md += `\`\`\`\n${msg.content}\n\`\`\`\n\n`;
+  }
+
+  // セッションIDベースのファイル名（同セッションは上書き）
+  const mdFile = path.join(logDir, `${sessionId}.md`);
+  const jsonlCopy = path.join(logDir, `${sessionId}.jsonl`);
+
+  fs.writeFileSync(mdFile, md, "utf8");
+  fs.copyFileSync(jsonlPath, jsonlCopy);
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,30 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/ci-log.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/save-session-log.js\"",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,5 +16,6 @@ jobs:
           cache: "npm"
 
       - run: npm ci
-      - run: npm test
       - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Claude Code session logs
+.claude/logs/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Claude Code hooks/scripts
+    ".claude/**",
   ]),
 ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "happy-dom": "^20.6.1",
         "jsdom": "^27.0.1",
         "typescript": "^5",
         "vitest": "^4.0.18"
@@ -2407,6 +2408,23 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4946,6 +4964,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.6.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.6.1.tgz",
+      "integrity": "sha512-+0vhESXXhFwkdjZnJ5DlmJIfUYGgIEEjzIjB+aKJbFuqlvvKyOi+XkI1fYbgYR9QCxG5T08koxsQ6HrQfa5gCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^6.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/has-bigints": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
@@ -22,6 +23,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "happy-dom": "^20.6.1",
     "jsdom": "^27.0.1",
     "typescript": "^5",
     "vitest": "^4.0.18"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## 目的（このPRで何ができるようになる？）
- PRを出すと自動で lint / typecheck / test が走り、結果が緑/赤で表示される
- Claude Codeセッション中のCI実行結果が自動でログ保存される

## 変更点（箇条書き）
- `.github/workflows/ci.yml`: typecheck ステップ追加（lint → typecheck → test の3段階に）
- `package.json`: `typecheck` スクリプト追加（`tsc --noEmit`）
- `vitest.config.ts`: 新規作成（happy-dom環境 + `@/` パスエイリアス）
- `eslint.config.mjs`: `.claude/**` をlint除外に追加
- `happy-dom`: devDependencyに追加（jsdom v27のESM互換性問題を回避）
- `.claude/settings.json`: PostToolUse CIログフック追加
- `.claude/hooks/ci-log.sh`: lint/typecheck/test実行時に結果を `.claude/logs/` に自動記録
- `.claude/hooks/save-session-log.js`: セッション終了時にログサマリーを保存
- `.gitignore`: `.claude/logs/` を除外に追加

## 動作確認（コピペで再現できる手順）
1. `npm ci`
2. `npm run lint` → エラーなし
3. `npm run typecheck` → エラーなし
4. `npm test` → 1 passed

## リスク / 影響範囲 / ロールバック
- 既存コードへの影響なし（CI設定とdev toolingのみ）
- ロールバック: このPRをrevertすれば元に戻る

## 関連Issue
- テンプレートリポジトリのCI基盤整備