### PR TITLE
docs: テーブル作成SQLを作成

### DIFF
--- a/supabase/create_tables.sql
+++ b/supabase/create_tables.sql
@@ -1,0 +1,52 @@
+-- ============================================
+-- Summary Slackbot — テーブル作成SQL
+-- ============================================
+-- ER図（docs/er-diagram.html）に基づいて作成
+-- Supabase（PostgreSQL）で実行する
+-- ============================================
+
+-- 1. workspaces（ワークスペース情報）
+CREATE TABLE workspaces (
+    id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    team_id     TEXT NOT NULL UNIQUE,
+    team_name   TEXT,
+    bot_token   TEXT NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    updated_at  TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+-- 2. channels（チャンネル情報）
+CREATE TABLE channels (
+    id            UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    workspace_id  UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    channel_id    TEXT NOT NULL,
+    channel_name  TEXT,
+    UNIQUE (workspace_id, channel_id)
+);
+
+-- 3. summaries（要約履歴）
+CREATE TABLE summaries (
+    id             UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    workspace_id   UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    channel_id     UUID REFERENCES channels(id) ON DELETE SET NULL,
+    slack_user_id  TEXT NOT NULL,
+    url            TEXT NOT NULL,
+    title          TEXT,
+    summary        TEXT NOT NULL,
+    summary_level  TEXT DEFAULT '普通',
+    llm_provider   TEXT DEFAULT 'anthropic',
+    created_at     TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+-- ============================================
+-- インデックス（検索を高速化）
+-- ============================================
+
+-- ユーザーごとの履歴取得を高速化
+CREATE INDEX idx_summaries_user ON summaries (slack_user_id, created_at DESC);
+
+-- 同じURLの重複チェックを高速化
+CREATE INDEX idx_summaries_url ON summaries (workspace_id, url);
+
+-- ワークスペースごとの検索を高速化
+CREATE INDEX idx_summaries_workspace ON summaries (workspace_id, created_at DESC);


### PR DESCRIPTION
## 目的（このPRで何ができるようになる？）
- SupabaseでDBテーブルを作成するためのSQLが用意され、DB構築に着手できる

## 変更点（箇条書き）
- supabase/create_tables.sql を新規作成
- workspacesテーブル（ワークスペース情報）
- channelsテーブル（チャンネル情報）
- summariesテーブル（要約履歴）
- 検索高速化用のインデックス3つを追加

## 動作確認（コピペで再現できる手順）
1. `supabase/create_tables.sql` を開く
2. 3つのCREATE TABLE文とインデックスが記載されていることを確認する

## リスク / 影響範囲 / ロールバック
- SQL定義のみの変更のため、実行しない限りDBへの影響なし
- ロールバックは `git revert` で対応可能

## 関連Issue
- Closes #16